### PR TITLE
make property and function to public

### DIFF
--- a/GPVideoClipper/GPVideoClipperView.swift
+++ b/GPVideoClipper/GPVideoClipperView.swift
@@ -25,19 +25,19 @@ open class GPVideoClipperView: UIView, UICollectionViewDelegate, UICollectionVie
     let kLineHeight: CGFloat = 3.0
     
     // Public
-    weak var delegate:GPVideoClipperViewDelegate?
-    var avAsset: AVAsset! {
+    public weak var delegate:GPVideoClipperViewDelegate?
+    public var avAsset: AVAsset! {
           willSet {
             self.avAsset = newValue
             self.p_loadThumbnailImages()
           }
     }
-    var progressTime: CGFloat! {
+    public var progressTime: CGFloat! {
         return (self.progressView.frame.minX - self.leftImageView.frame.maxX) / self.perSecondWidth
     }
-    
-    // Private
-    private var maker: GPVideoConfigMaker!
+    public var maker: GPVideoConfigMaker!
+
+	// Private
     private var selectedTime: CGFloat!
     private var cellWidth: CGFloat!
     private var cellCount: UInt!
@@ -298,7 +298,7 @@ open class GPVideoClipperView: UIView, UICollectionViewDelegate, UICollectionVie
     
     //MARK: - Init
     
-    init(frame: CGRect, maker: GPVideoConfigMaker) {
+    public init(frame: CGRect, maker: GPVideoConfigMaker) {
         self.maker = maker
         super.init(frame: frame)
         self.isUserInteractionEnabled = true
@@ -388,7 +388,7 @@ open class GPVideoClipperView: UIView, UICollectionViewDelegate, UICollectionVie
     
     //MARK: - Public
     
-    func gp_updateProgressViewWithProgress(_ progress: CGFloat) {
+    public func gp_updateProgressViewWithProgress(_ progress: CGFloat) {
         guard self.selectedImageView != nil else {
             let width = self.rightImageView.frame.minX - self.leftImageView.frame.maxX;
             let newX = self.leftImageView.frame.maxX + progress * width;

--- a/GPVideoClipper/GPVideoConfigMaker.swift
+++ b/GPVideoClipper/GPVideoConfigMaker.swift
@@ -25,37 +25,37 @@ open class GPVideoConfigMaker: NSObject {
     
     // MARK: - Optional
     /** 是否隐藏已选择时间标签 */
-    var isHiddenSelectedTimeTag: Bool
+    public var isHiddenSelectedTimeTag: Bool
     /** 选择框颜色 */
-    var selectedBoxColor: UIColor
+    public var selectedBoxColor: UIColor
     /** 左边框图片 */
-    var leftSelectedImage: UIImage
+    public var leftSelectedImage: UIImage
     /** 右边框图片 */
-    var rightSelectedImage: UIImage
+    public var rightSelectedImage: UIImage
     /** 左右选择框图片的宽度 */
-    var selectedImageWidth: CGFloat
+    public var selectedImageWidth: CGFloat
     /** 初始化时选择框中选中的图片张数 */
-    var defaultSelectedImageCount: UInt
+    public var defaultSelectedImageCount: UInt
     /** 选择框整体左间距 */
-    var leftMargin: CGFloat
+    public var leftMargin: CGFloat
     /** 选择框整体右间距 */
-    var rightMargin: CGFloat
+    public var rightMargin: CGFloat
     /** 左边按钮字体 */
-    var leftButtonFont: UIFont
+    public var leftButtonFont: UIFont
     /** 左边按钮文字颜色 */
-    var leftButtonFontColor: UIColor
+    public var leftButtonFontColor: UIColor
     /** 左边按钮背景色 */
-    var leftButtonBackgroundColor: UIColor
+    public var leftButtonBackgroundColor: UIColor
     /** 左边按钮标题 */
-    var leftButtonTitle: String
+    public var leftButtonTitle: String
     /** 右边按钮字体 */
-    var rightButtonFont: UIFont
+    public var rightButtonFont: UIFont
     /** 右边按钮文字颜色 */
-    var rightButtonFontColor: UIColor
+    public var rightButtonFontColor: UIColor
     /** 右边按钮背景色 */
-    var rightButtonBackgroundColor: UIColor
+    public var rightButtonBackgroundColor: UIColor
     /** 右边按钮标题 */
-    var rightButtonTitle: String
+    public var rightButtonTitle: String
     
     override init() {
         startTime = 0

--- a/GPVideoClipper/GPVideoPlayerView.swift
+++ b/GPVideoClipper/GPVideoPlayerView.swift
@@ -14,15 +14,15 @@ import AVFoundation
 }
 
 open class GPVideoPlayerView: UIView {
-    var playerItem: AVPlayerItem!
-    var player: AVPlayer!
-    var maker: GPVideoConfigMaker!
-    weak var delegate:GPVideoPlayerViewDelegate?
+    public var playerItem: AVPlayerItem!
+    public var player: AVPlayer!
+    public var maker: GPVideoConfigMaker!
+    public weak var delegate:GPVideoPlayerViewDelegate?
     
     private var avPlayer: AVPlayerLayer!
     private var videoURL: URL!
     
-    init(frame: CGRect, videoURL: URL) {
+    public init(frame: CGRect, videoURL: URL) {
         self.videoURL = videoURL
         self.playerItem = AVPlayerItem.init(url: videoURL)
         self.player = AVPlayer.init(playerItem: self.playerItem)


### PR DESCRIPTION
如果通过CocoaPod引入了这个库，但是不直接使用GPVideoClipperController， 而是只使用其他组件（GPVideoPlayerView、GPVideoClipperView）创建一个自定义UI的Clipper  Controller， 那么你会发现有些属性和方法因为是internal的关系，不能被访问，我把他们重新声明为public，这样就可以使用他们了